### PR TITLE
Fixes for modern devices

### DIFF
--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -142,7 +142,7 @@ static bool unlock_global_acpi_lock(void)
 #define AYANEO_LED_GROUP_BUTTON     0x04
 
 #define AYANEO_LED_WRITE_DELAY_LEGACY_MS        2
-#define AYANEO_LED_WRITE_DELAY_MS               10
+#define AYANEO_LED_WRITE_DELAY_MS               1
 #define AYANEO_LED_WRITER_DELAY_RANGE_US        10000, 20000
 
 enum ayaneo_model {
@@ -355,6 +355,27 @@ static void ayaneo_led_mc_release(void)
 static void ayaneo_led_mc_hold(void)
 {
         ec_write_ram(AYANEO_LED_MC_MODE_ADDR, AYANEO_LED_MC_MODE_HOLD);
+
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
+
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x02, 0xba);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x02, 0xba);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x0f, 0x00);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x0f, 0x00);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x10, 0x00);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x10, 0x00);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x11, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x11, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x12, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x12, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x13, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x13, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x14, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x14, 0x05);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT, 0x15, 0x07);
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_RIGHT, 0x15, 0x07);
+
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
 }
 
 static void ayaneo_led_mc_intensity(u8 group, u8 *color, u8 zones[])
@@ -366,6 +387,9 @@ static void ayaneo_led_mc_intensity(u8 group, u8 *color, u8 zones[])
                 ayaneo_led_mc_set(group, zones[zone] + 1, color[1]);
                 ayaneo_led_mc_set(group, zones[zone] + 2, color[2]);
         }
+
+        // note: omit for aya flip when implemented, causes unexpected behavior
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
 }
 
 static void ayaneo_led_mc_off(void)
@@ -373,6 +397,9 @@ static void ayaneo_led_mc_off(void)
         ec_write_ram(AYANEO_LED_MC_ENABLE_ADDR, AYANEO_LED_MC_ENABLE_OFF);
         ec_write_ram(AYANEO_LED_MC_ADDR_CLOSE_1, 0x01);
         mdelay(AYANEO_LED_WRITE_DELAY_MS);
+
+        // note: omit for aya flip when implemented, causes unexpected behavior
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
 }
 
 static void ayaneo_led_mc_on(void)
@@ -380,6 +407,9 @@ static void ayaneo_led_mc_on(void)
         ec_write_ram(AYANEO_LED_MC_ENABLE_ADDR, AYANEO_LED_MC_ENABLE_ON);
         ec_write_ram(AYANEO_LED_MC_ADDR_CLOSE_1, 0x01);
         mdelay(AYANEO_LED_WRITE_DELAY_MS);
+
+        // note: omit for aya flip when implemented, causes unexpected behavior
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
 }
 
 static void ayaneo_led_mc_reset(void)
@@ -387,6 +417,9 @@ static void ayaneo_led_mc_reset(void)
         ec_write_ram(AYANEO_LED_MC_ENABLE_ADDR, AYANEO_LED_MC_ENABLE_RESET);
         ec_write_ram(AYANEO_LED_MC_ADDR_CLOSE_1, 0x01);
         mdelay(AYANEO_LED_WRITE_DELAY_MS);
+
+        // note: omit for aya flip when implemented, causes unexpected behavior
+        ayaneo_led_mc_set(AYANEO_LED_GROUP_LEFT_RIGHT, 0x00, 0x00);
 }
 
 /* ACPI controller methods */
@@ -704,6 +737,7 @@ static void ayaneo_led_mc_brightness_apply(u8 *color)
         }
 }
 
+int ayaneo_led_mc_writer(void *pv);
 int ayaneo_led_mc_writer(void *pv)
 {
         pr_info("Writer thread started.\n");

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -609,9 +609,9 @@ static void ayaneo_led_mc_release_control(void)
 # syncronised by ayaneo_led_mc_update_lock to prevent a race condition between
 # the writer thread and the brightness set function.
 #
-# During suspend the kthread_stop is called which causes the writer thread to
-# terminate after its current iteration. Th writer thread is then restarted
-# during resume to allow updates to continue.
+# During suspend kthread_stop is called which causes the writer thread to
+# terminate after its current iteration. The writer thread is restarted during
+# resume to allow updates to continue.
 */
 static struct task_struct *ayaneo_led_mc_writer_thread;
 static int ayaneo_led_mc_update_required;

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -859,9 +859,33 @@ static ssize_t suspend_mode_store(struct device *dev, struct device_attribute *a
 static DEVICE_ATTR_RW(suspend_mode);
 
 static struct attribute *ayaneo_led_mc_attrs[] = {
-        &dev_attr_suspend_mode.attr,
+        NULL,
         NULL,
 };
+
+static void suspend_mode_register_attr(void)
+{
+        switch (model) {
+                case air:
+                case air_1s:
+                case air_1s_limited:
+                case air_pro:
+                case air_plus_mendo:
+                case geek:
+                case geek_1s:
+                case ayaneo_2:
+                case ayaneo_2s:
+                case kun:
+                        ayaneo_led_mc_attrs[0] = &dev_attr_suspend_mode.attr;
+                        break;
+                case air_plus:
+                case slide:
+                        // Not currently working; do not register
+                        break;
+                default:
+                        break;
+        }
+}
 
 ATTRIBUTE_GROUPS(ayaneo_led_mc);
 
@@ -948,6 +972,7 @@ static int ayaneo_platform_probe(struct platform_device *pdev)
                 return ret;
 
         model = (enum ayaneo_model)match->driver_data;
+        suspend_mode_register_attr();
         ayaneo_led_mc_take_control();
 
         ret = devm_led_classdev_multicolor_register(dev, &ayaneo_led_mc);


### PR DESCRIPTION
This change implements temporary fixes for modern devices:
* Re-implement equivalent chain of initialization commands. They're not well understood yet, but do work.
* Prevent registering suspend_mode attribute on devices where it's giving trouble.