### PR TITLE
Corrects inconsistent RGB on Ayaneo Air family of devices.

### DIFF
--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -716,7 +716,6 @@ static void ayaneo_led_mc_brightness_apply(u8 *color)
                 case air:
                 case air_pro:
                 case air_1s:
-                        //ayaneo_led_mc_scale_color(color_l, 69);
                         ayaneo_led_mc_legacy_on();
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_LEFT, color_l, zones);
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_RIGHT, color_r, zones);

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -716,7 +716,7 @@ static void ayaneo_led_mc_brightness_apply(u8 *color)
                 case air:
                 case air_pro:
                 case air_1s:
-                        ayaneo_led_mc_scale_color(color_l, 69);
+                        //ayaneo_led_mc_scale_color(color_l, 69);
                         ayaneo_led_mc_legacy_on();
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_LEFT, color_l, zones);
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_RIGHT, color_r, zones);


### PR DESCRIPTION
The left and right RGB are out of sync with the latest platform driver, I was able to verify the behavior on an Air Pro.  Commenting ayaneo_led_mc_scale_color resolved the issue, and the brightness scales correctly on both when initialized and when changed with HueSync.

We've bumped our kernel which includes the fix, and shared with [judjdigj](https://github.com/judjdigj) to see if it also resolves #21 on the 1S (it should).