### PR TITLE
Quick fix for 6.13.

### DIFF
--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -716,7 +716,6 @@ static void ayaneo_led_mc_brightness_apply(u8 *color)
                 case air:
                 case air_pro:
                 case air_1s:
-                        //ayaneo_led_mc_scale_color(color_l, 69);
                         ayaneo_led_mc_legacy_on();
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_LEFT, color_l, zones);
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_RIGHT, color_r, zones);

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -1016,7 +1016,7 @@ static struct platform_driver ayaneo_platform_driver = {
         .resume = ayaneo_platform_resume,
         .suspend = ayaneo_platform_suspend,
         .shutdown = ayaneo_platform_shutdown,
-        .remove_new = ayaneo_platform_remove,
+        .remove = ayaneo_platform_remove,
 };
 
 static struct platform_device *ayaneo_platform_device;

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -716,7 +716,7 @@ static void ayaneo_led_mc_brightness_apply(u8 *color)
                 case air:
                 case air_pro:
                 case air_1s:
-                        ayaneo_led_mc_scale_color(color_l, 69);
+                        //ayaneo_led_mc_scale_color(color_l, 69);
                         ayaneo_led_mc_legacy_on();
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_LEFT, color_l, zones);
                         ayaneo_led_mc_legacy_intensity(AYANEO_LED_GROUP_RIGHT, color_r, zones);


### PR DESCRIPTION
6.13 seems to require .remove rather than .remove_new.  Works fine with my test kernel.