### PR TITLE
Add ayaneos bypass charge function and expose it via sysfs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,12 @@ On most systems this will be mounted/hooked at `/sys/class/power_supply/BAT*/` a
 
 Read/write.
 
-Enables or disables the bypass charge. Accepts a value of "Standard", "Limit" and "Bypass".
+Enables or disables the bypass charge. Accepts a value of "Standard" and "Bypass".
 When reading, the currently selected option will be wrapped in square brackets `[ ]`.
 
 |Value|Description|
 |-|-|
 |"Standard"|Disables the bypass charge. The battery is normally charged.|
-|"Limit"|Enables the bypass charge. Battery charging will depend only on the stop value.|
 |"Bypass"|Enables the bypass charge. Battery charging will depend on the start and stop values.|
 
 Default is "Standard"
@@ -154,15 +153,15 @@ Default is 100.
 The current charge type and end threshold can be retrieved as follows:
 ```shell
 $ cat /sys/class/power_supply/BAT*/charge_type
-[Standard] Limit Bypass
+[Standard] Bypass
 $ cat /sys/class/power_supply/BAT*/charge_control_end_threshold
 100
 ```
 
 New values can be set as follows:
 ```shell
-$ echo "Limit" | sudo tee /sys/class/power_supply/BAT*/charge_type
-Limit
+$ echo "Bypass" | sudo tee /sys/class/power_supply/BAT*/charge_type
+Bypass
 $ echo "80" | sudo tee /sys/class/power_supply/BAT*/charge_control_end_threshold
 80
 ```

--- a/README.md
+++ b/README.md
@@ -116,20 +116,20 @@ $ echo "255 0 128" | sudo tee /sys/class/leds/ayaneo:rgb:joystick_rings/multi_in
 
 Bypass Charge Control can be enabled, disabled, start and stop battery level can be set via sysfs.
 
-On most systems this will be mounted/hooked at `/sys/class/power_supply/BAT0/` and provides the following files:
+On most systems this will be mounted/hooked at `/sys/class/power_supply/BAT*/` and provides the following files:
 
 #### charge_type
 
 Read/write.
 
-Enables or disables the bypass charge. Accepts a value of "Standard", "Cycle" and "Bypass".
+Enables or disables the bypass charge. Accepts a value of "Standard", "Limit" and "Bypass".
 When reading, the currently selected option will be wrapped in square brackets `[ ]`.
 
 |Value|Description|
 |-|-|
 |"Standard"|Disables the bypass charge. The battery is normally charged.|
-|"Cycle"|Enables the bypass charge. Battery charging will depend on the start and stop values.|
-|"Bypass"|Enables the bypass charge regardless the battery level.|
+|"Limit"|Enables the bypass charge. Battery charging will depend only on the stop value.|
+|"Bypass"|Enables the bypass charge. Battery charging will depend on the start and stop values.|
 
 Default is "Standard"
 
@@ -153,17 +153,17 @@ Default is 100.
 
 The current charge type and end threshold can be retrieved as follows:
 ```shell
-$ cat /sys/class/power_supply/ayaneo:bypass_charge/charge_type
-[Standard] Cycle Bypass
-$ cat /sys/class/power_supply/ayaneo:bypass_charge/charge_control_end_threshold
+$ cat /sys/class/power_supply/BAT*/charge_type
+[Standard] Limit Bypass
+$ cat /sys/class/power_supply/BAT*/charge_control_end_threshold
 100
 ```
 
 New values can be set as follows:
 ```shell
-$ echo "Cycle" | sudo tee /sys/class/power_supply/ayaneo:bypass_charge/charge_type
-Cycle
-$ echo "80" | sudo tee /sys/class/power_supply/ayaneo:bypass_charge/charge_control_end_threshold
+$ echo "Limit" | sudo tee /sys/class/power_supply/BAT*/charge_type
+Limit
+$ echo "80" | sudo tee /sys/class/power_supply/BAT*/charge_control_end_threshold
 80
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,58 +112,38 @@ $ echo "255 0 128" | sudo tee /sys/class/leds/ayaneo:rgb:joystick_rings/multi_in
 255 0 128
 ```
 
-### Bypass Charge Control
+### Power Supply Charge Behaviour
 
-Bypass Charge Control can be enabled, disabled, start and stop battery level can be set via sysfs.
+Power Supply Charge Behaviour can be set to Auto or Inhibit Charge via sysfs.
 
 On most systems this will be mounted/hooked at `/sys/class/power_supply/BAT*/` and provides the following files:
 
-#### charge_type
+#### charge_behaviour
 
 Read/write.
 
-Enables or disables the bypass charge. Accepts a value of "Standard" and "Bypass".
+Enables or disables the bypass charge. Accepts a value of "auto" and "inhibit-charge".
 When reading, the currently selected option will be wrapped in square brackets `[ ]`.
 
 |Value|Description|
 |-|-|
-|"Standard"|Disables the bypass charge. The battery is normally charged.|
-|"Bypass"|Enables the bypass charge. Battery charging will depend on the start and stop values.|
+|"auto"|Disables the bypass charge. The battery is normally charged.|
+|"inhibit-charge"|Enables the bypass charge. Battery charging will be stopped.|
 
-Default is "Standard"
-
-#### charge_control_start_threshold
-
-Read/write.
-
-Gets or sets the battery percentage level, below which charging will begin. Valid values between 0 and 100 (percent).
-
-Default is 100.
-
-#### charge_control_end_threshold
-
-Read/write.
-
-Gets or sets the battery percentage level, on or above which charging will stop. Valid values between 0 and 100 (percent).
-
-Default is 100.
+Default is "auto"
 
 #### Identifying and Setting Control Values
 
 The current charge type and end threshold can be retrieved as follows:
 ```shell
 $ cat /sys/class/power_supply/BAT*/charge_type
-[Standard] Bypass
-$ cat /sys/class/power_supply/BAT*/charge_control_end_threshold
-100
+[auto] inhibit-charge
 ```
 
 New values can be set as follows:
 ```shell
-$ echo "Bypass" | sudo tee /sys/class/power_supply/BAT*/charge_type
-Bypass
-$ echo "80" | sudo tee /sys/class/power_supply/BAT*/charge_control_end_threshold
-80
+$ echo "inhibit-charge" | sudo tee /sys/class/power_supply/BAT*/charge_type
+inhibit-charge
 ```
 
 ## Changing Startup Defaults

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -968,11 +968,10 @@ struct led_classdev_mc ayaneo_led_mc = {
 
 /* Handling bypass charge */
 enum charge_type_value_index {
-    CHARGETYPE_STANDARD, CHARGETYPE_LIMIT, CHARGETYPE_BYPASS,
+    CHARGETYPE_STANDARD, CHARGETYPE_BYPASS,
 };
 static const char * const charge_type_strings[] = {
     [CHARGETYPE_STANDARD] = "Standard",
-    [CHARGETYPE_LIMIT] = "Limit",
     [CHARGETYPE_BYPASS] = "Bypass",
 };
 struct ayaneo_ps_priv {
@@ -1176,50 +1175,7 @@ int ayaneo_bypass_charge_writer(void *pv)
         while (!kthread_should_stop())
         {
             if(last_charge_type != ps_priv.charge_type) {
-                if(ps_priv.charge_type == CHARGETYPE_LIMIT) {
-                    ret = power_supply_get_property(ps_priv.battery, POWER_SUPPLY_PROP_CAPACITY, &capacity);
-                    if(!ret) {
-                        if(capacity.intval >= ps_priv.current_end_threshold) {
-                            switch (model) {
-                                case air:
-                                case air_1s:
-                                case air_1s_limited:
-                                case air_pro:
-                                case air_plus_mendo:
-                                case geek_1s:
-                                case ayaneo_2s:
-                                case kun:
-                                        ayaneo_bypass_charge_legacy_open();
-                                        break;
-                                case air_plus:
-                                case slide:
-                                        ayaneo_bypass_charge_open();
-                                        break;
-                                default:
-                                        break;
-                            }
-                        } else {
-                            switch (model) {
-                                case air:
-                                case air_1s:
-                                case air_1s_limited:
-                                case air_pro:
-                                case air_plus_mendo:
-                                case geek_1s:
-                                case ayaneo_2s:
-                                case kun:
-                                        ayaneo_bypass_charge_legacy_close();
-                                        break;
-                                case air_plus:
-                                case slide:
-                                        ayaneo_bypass_charge_close();
-                                        break;
-                                default:
-                                        break;
-                            }
-                        }
-                    }
-                } else if (CHARGETYPE_BYPASS == ps_priv.charge_type){
+                if (CHARGETYPE_BYPASS == ps_priv.charge_type){
                     ret = power_supply_get_property(ps_priv.battery, POWER_SUPPLY_PROP_CAPACITY, &capacity);
                     if(!ret) {
                         if(capacity.intval >= ps_priv.current_end_threshold) {

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -1230,12 +1230,12 @@ static int ayaneo_check_charge_control(void)
                     break;
             case air_plus:
             case slide:
-                    version_needed[0] = 0x1b;
-                    version_needed[1] = 0;
+                    version_needed[0] = 0;
+                    version_needed[1] = 0x1b;
                     version_needed[2] = 0;
                     version_needed[3] = 0;
                     version_needed[4] = 0;
-                    version_length = 1;
+                    version_length = 2;
                     break;
             default:
                     return -1;


### PR DESCRIPTION
Hey, 
here is the bypass charge function.

Let's discuss if the path name is reasonable and the properties are understandable. I looked up the power_supply doc and source code of the linux kernel.
I also found out that in some upcoming release we can also add these properties to the BAT0 path, so we get ride of an virtual power_supply, we have created at the moment.

I have done testing the version check function, if my device version is below it wont show the power_supply path and will not activate bypass charge. On suspend and resume the ec will hold the bypass charge settings and will not charge the battery. On shutdown the ec values for bypass charge get lost and battery will start charging.

My device is the Air Plus 7320u.