### PR TITLE
Add support for SuiPlay0X1 RGB in ayaneo-platform

### DIFF
--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -241,6 +241,15 @@ static const struct dmi_system_id dmi_table[] = {
                         DMI_EXACT_MATCH(DMI_BOARD_NAME, "AYANEO 2S"),
                 },
                 .driver_data = (void *)ayaneo_2s,
+
+        },
+        {
+                .matches = {
+                        DMI_EXACT_MATCH(DMI_BOARD_VENDOR, "Mysten Labs, Inc."),
+                        DMI_EXACT_MATCH(DMI_BOARD_NAME, "SuiPlay0X1"),
+                },
+                .driver_data = (void *)ayaneo_2s,
+
         },
         {
                 .matches = {

--- a/ayaneo-platform.c
+++ b/ayaneo-platform.c
@@ -241,7 +241,6 @@ static const struct dmi_system_id dmi_table[] = {
                         DMI_EXACT_MATCH(DMI_BOARD_NAME, "AYANEO 2S"),
                 },
                 .driver_data = (void *)ayaneo_2s,
-
         },
         {
                 .matches = {
@@ -249,7 +248,6 @@ static const struct dmi_system_id dmi_table[] = {
                         DMI_EXACT_MATCH(DMI_BOARD_NAME, "SuiPlay0X1"),
                 },
                 .driver_data = (void *)ayaneo_2s,
-
         },
         {
                 .matches = {


### PR DESCRIPTION
Hi @pastaq,

As mentioned from our email convo, I've added the changes for adding RGB support for the Suiplay0X1 handheld (Rebrand of the Ayaneo 2s).

Thanks and regards,
Mark Torres